### PR TITLE
Bump Chasm to 0.9.4, WEH to 0.2

### DIFF
--- a/.github/workflows/Run.yml
+++ b/.github/workflows/Run.yml
@@ -52,24 +52,3 @@ jobs:
 
       - name: Assemble run
         run: ./gradlew chasm-runner:jvmRun chasm-runner:runReleaseExecutableMacosX64
-
-  run-windows:
-    name: Run tests on Windows
-    runs-on: windows-latest
-    timeout-minutes: 60
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'corretto'
-          java-version: '23'
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-
-      - name: Assemble run
-        run: ./gradlew chasm-runner:jvmRun chasm-runner:runReleaseExecutableMingwX64

--- a/chasm-runner/build.gradle.kts
+++ b/chasm-runner/build.gradle.kts
@@ -46,9 +46,10 @@ kotlin {
     linuxX64()
     macosArm64()
     macosX64()
-    mingwX64 {
-        binaries.all { linkerOpts("-lntdll") }
-    }
+//  Mingw target is not yet in Chasm
+//  mingwX64 {
+//      binaries.all { linkerOpts("-lntdll") }
+//  }
 
     targets.withType<KotlinNativeTarget> {
         binaries.executable {
@@ -87,7 +88,7 @@ tasks.withType<JavaExec>().configureEach {
     jvmArgs(
         "-XX:+HeapDumpOnOutOfMemoryError",
         "-XX:MaxMetaspaceSize=128M",
-        "-Xmx4G",
+        "-Xmx8G",
     )
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
 kotlin = "2.1.0"
-chasm = "0.9.2"
+chasm = "0.9.4"
 kotlinx-coroutines = "1.10.1"
 kotlinx-io = "0.6.0"
-wasi-emscripten-host = "0.1"
+wasi-emscripten-host = "0.2"
 
 [libraries]
 chasm = { group = "io.github.charlietap.chasm", name = "chasm", version.ref = "chasm" }


### PR DESCRIPTION
* MinGW target is disabled since Windows support is temporarily dropped in Chasm.
* Memory limit for JavaExec increased up to 8G due to increased memory consumption